### PR TITLE
Task 7: Add auth header for import function

### DIFF
--- a/src/components/pages/PageProductForm/PageProductForm.tsx
+++ b/src/components/pages/PageProductForm/PageProductForm.tsx
@@ -113,9 +113,10 @@ export default function PageProductForm() {
     if (id) {
       // TODO: do PUT request to update existing product (will be implemented in the next tasks)
     } else {
-      // add new product (TASK 4)
+      // Just for testing purposes (queryAuthorizer); not required in Task 7
+      const token = localStorage.getItem("authorization_token") || "";
       axios
-        .post(`${API_PATHS.bff}/products`, productToSave)
+        .post(`${API_PATHS.bff}/products?token=${token}`, productToSave)
         .then(() => history.push("/admin/products"));
     }
   };

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -38,12 +38,14 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
 
   const uploadFile = async (e: any) => {
     if (isFileCSV(file)) {
+      const token = localStorage.getItem("authorization_token") || "";
+      const headers = token ? { Authorization: `Basic ${token}` } : {};
+
       const signedUrlResponse = await axios({
-        method: 'GET',
+        method: "GET",
         url,
-        params: {
-          name: encodeURIComponent(file.name)
-        }
+        headers,
+        params: { name: encodeURIComponent(file.name) },
       });
 
       console.log('File to upload: ', file.name);

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -37,7 +37,13 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
   };
 
   const uploadFile = async (e: any) => {
-    if (isFileCSV(file)) {
+    if (!isFileCSV(file)) {
+      alert('Please, select CSV file');
+      setFile('');
+      return;
+    }
+
+    try {
       const token = localStorage.getItem("authorization_token") || "";
       const headers = token ? { Authorization: `Basic ${token}` } : {};
 
@@ -57,11 +63,12 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
         headers: { 'Content-Type': 'text/csv' },
       });
 
+      alert('File was uploaded successfully');
       console.log('Result: ', result);
-    } else {
-      console.error('File format should be CSV');
+      setFile('');
+    } catch (err) {
+      console.log('Error during file upload', err);
     }
-    setFile('');
   };
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,9 +13,18 @@ axios.interceptors.response.use(
     return response;
   },
   function(error) {
-    if (error.response.status === 400) {
-      alert(error.response.data?.data);
+    switch (error.response.status) {
+      case 400:
+        alert(error.response.data?.data);
+        break;
+      case 401:
+        alert("Unauthorized request (authorization header is not provided)");
+        break;
+      case 403:
+        alert("Access denied (invalid authorization token)");
+        break;
     }
+
     return Promise.reject(error.response);
   }
 );


### PR DESCRIPTION
### Task link: https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task7-lambda%2Bcognito-authorization/task.md
- update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage

### BE PR: https://github.com/shohrukh92/shop-be/pull/5